### PR TITLE
Add title to describe kind of support

### DIFF
--- a/src/components/Modules/MLogosGallery.vue
+++ b/src/components/Modules/MLogosGallery.vue
@@ -23,8 +23,8 @@ const { items, showLink } = toRefs(props)
   <div class="flex flex-wrap">
     <a v-for="(item, index) in items" :key="index" :href="item.web" target="_blank"
       class="text-center w-1/2 my-4 md:w-1/3">
-      <span v-if="item.title" class="text-xs">{{ item.title }}</span>
       <img :title="item.title" :src="getImageUrl(item.logo)" class="w-32 max-w-32 block mx-auto" />
+      <span v-if="item.title" class="text-xs">[{{ item.title }}]</span>
       <a-link :href="item.web" target="_blank" v-if="showLink">{{ item.name }}</a-link>
     </a>
   </div>

--- a/src/content.ts
+++ b/src/content.ts
@@ -25,12 +25,13 @@ export const supporters: ILogo[] = [
     logo: 'ajuntament.png',
     name: 'Ajuntament de Girona',
     web: 'https://web.girona.cat/',
-    title: 'Amb el finançament de:'
+    title: 'finançament'
   },
   {
     logo: 'assoc-catosfera-logo-2019.png',
     name: 'Catosfera',
-    web: 'https://catosfera.cat/'
+    web: 'https://catosfera.cat/',
+    title: 'espais i logística'
   }
 ]
 


### PR DESCRIPTION
To improve UX, integrate details about the support for each supporter after the logo

![image](https://github.com/GeeksCAT/hacktoberfest-web-2022/assets/8709244/53abdd6c-28dc-49e8-8663-c1c892887b19)
